### PR TITLE
0.11.0 ~ Null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2021-03-13
+
+### Changed
+
+- Adjustments to null safety
+- Function `merge` has been deprecated due to null-safety changes.
+- Updated dependencies:
+    - http: ^0.13.0
+    - json_annotation: ^4.0.0
+- Updated development dependencies:
+    - json_serializable: ^4.0.2
+    - build_runner: ^1.12.1
+    - pedantic: ^1.11.0
+- Added dependency override to prevent version discrepancies:
+    - build: ^2.0.0
+
+
 ## [0.10.0] - 2021-03-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,8 @@ All notable changes to this project will be documented in this file.
     - json_annotation: ^4.0.0
 - Updated development dependencies:
     - json_serializable: ^4.0.2
-    - build_runner: ^1.12.1
+    - build_runner: ^1.10.1
     - pedantic: ^1.11.0
-- Added dependency override to prevent version discrepancies:
-    - build: ^2.0.0
-
 
 ## [0.10.0] - 2021-03-10
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -14,7 +14,7 @@ void main(List<String> arguments) async {
   final client = FaunaClient(config);
 
   final query = Paginate(Collections());
-  print('query=>\n${query}');
+  print('query=>\n$query');
 
   final response = await client.query(query);
   if (response.hasErrors) {

--- a/lib/src/FaunaClient.dart
+++ b/lib/src/FaunaClient.dart
@@ -71,11 +71,14 @@ class FaunaClient {
   ///
   /// Throws [TimeoutException] if query response is not received within
   /// [config.timeout].
-  Future<FaunaResponse> query(Object expression, {FaunaConfig options}) {
-    final config = (options == null ? this.config : this.config.merge(options));
+  Future<FaunaResponse> query(Object expression, {FaunaConfig? options}) {
+    final config = (options ?? this.config);
     return _httpClient
         .post(
-          config.baseUrl,
+          Uri(
+            scheme: config.scheme.toString().split('.')[1].toLowerCase(),
+            host: config.domain,
+          ),
           headers: config.requestHeaders,
           body: json.encode(expression),
         )

--- a/lib/src/fql/array_and_set.dart
+++ b/lib/src/fql/array_and_set.dart
@@ -197,7 +197,7 @@ class Match extends Expr {
   final Object index;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final List terms;
+  final List? terms;
 
   Match(this.index, {this.terms});
 

--- a/lib/src/fql/array_and_set.g.dart
+++ b/lib/src/fql/array_and_set.g.dart
@@ -8,8 +8,8 @@ part of 'array_and_set.dart';
 
 Append _$AppendFromJson(Map<String, dynamic> json) {
   return Append(
-    json['append'],
-    json['collection'],
+    json['append'] as Object,
+    json['collection'] as Object,
   );
 }
 
@@ -20,7 +20,7 @@ Map<String, dynamic> _$AppendToJson(Append instance) => <String, dynamic>{
 
 Count _$CountFromJson(Map<String, dynamic> json) {
   return Count(
-    json['count'],
+    json['count'] as Object,
   );
 }
 
@@ -30,7 +30,7 @@ Map<String, dynamic> _$CountToJson(Count instance) => <String, dynamic>{
 
 Distinct _$DistinctFromJson(Map<String, dynamic> json) {
   return Distinct(
-    json['distinct'],
+    json['distinct'] as Object,
   );
 }
 
@@ -40,8 +40,8 @@ Map<String, dynamic> _$DistinctToJson(Distinct instance) => <String, dynamic>{
 
 Drop _$DropFromJson(Map<String, dynamic> json) {
   return Drop(
-    json['drop'],
-    json['collection'],
+    json['drop'] as Object,
+    json['collection'] as Object,
   );
 }
 
@@ -52,8 +52,8 @@ Map<String, dynamic> _$DropToJson(Drop instance) => <String, dynamic>{
 
 Filter _$FilterFromJson(Map<String, dynamic> json) {
   return Filter(
-    json['collection'],
-    json['filter'] ?? Lambda.fromJson(json['filter'] as Map<String, dynamic>),
+    json['collection'] as Object,
+    Lambda.fromJson(json['filter'] as Map<String, dynamic>),
   );
 }
 
@@ -64,8 +64,8 @@ Map<String, dynamic> _$FilterToJson(Filter instance) => <String, dynamic>{
 
 Foreach _$ForeachFromJson(Map<String, dynamic> json) {
   return Foreach(
-    json['foreach'],
-    json['lambda'] ?? Lambda.fromJson(json['lambda'] as Map<String, dynamic>),
+    json['foreach'] as Object,
+    Lambda.fromJson(json['lambda'] as Map<String, dynamic>),
   );
 }
 
@@ -76,7 +76,7 @@ Map<String, dynamic> _$ForeachToJson(Foreach instance) => <String, dynamic>{
 
 Intersection _$IntersectionFromJson(Map<String, dynamic> json) {
   return Intersection(
-    json['intersection'],
+    json['intersection'] as Object,
   );
 }
 
@@ -87,7 +87,7 @@ Map<String, dynamic> _$IntersectionToJson(Intersection instance) =>
 
 IsEmpty _$IsEmptyFromJson(Map<String, dynamic> json) {
   return IsEmpty(
-    json['is_empty'],
+    json['is_empty'] as Object,
   );
 }
 
@@ -97,7 +97,7 @@ Map<String, dynamic> _$IsEmptyToJson(IsEmpty instance) => <String, dynamic>{
 
 IsNonEmpty _$IsNonEmptyFromJson(Map<String, dynamic> json) {
   return IsNonEmpty(
-    json['is_non_empty'],
+    json['is_non_empty'] as Object,
   );
 }
 
@@ -108,8 +108,8 @@ Map<String, dynamic> _$IsNonEmptyToJson(IsNonEmpty instance) =>
 
 Join _$JoinFromJson(Map<String, dynamic> json) {
   return Join(
-    json['join'],
-    json['with'],
+    json['join'] as Object,
+    json['with'] as Object,
   );
 }
 
@@ -120,8 +120,8 @@ Map<String, dynamic> _$JoinToJson(Join instance) => <String, dynamic>{
 
 Map_ _$Map_FromJson(Map<String, dynamic> json) {
   return Map_(
-    json['collection'],
-    json['map'] ?? Lambda.fromJson(json['map'] as Map<String, dynamic>),
+    json['collection'] as Object,
+    Lambda.fromJson(json['map'] as Map<String, dynamic>),
   );
 }
 
@@ -133,8 +133,8 @@ Map<String, dynamic> _$Map_ToJson(Map_ instance) => <String, dynamic>{
 Match _$MatchFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['terms']);
   return Match(
-    json['match'],
-    terms: json['terms'] as List,
+    json['match'] as Object,
+    terms: json['terms'] as List<dynamic>?,
   );
 }
 
@@ -155,8 +155,8 @@ Map<String, dynamic> _$MatchToJson(Match instance) {
 
 Prepend _$PrependFromJson(Map<String, dynamic> json) {
   return Prepend(
-    json['prepend'],
-    json['collection'],
+    json['prepend'] as Object,
+    json['collection'] as Object,
   );
 }
 
@@ -167,8 +167,7 @@ Map<String, dynamic> _$PrependToJson(Prepend instance) => <String, dynamic>{
 
 Singleton _$SingletonFromJson(Map<String, dynamic> json) {
   return Singleton(
-    json['singleton'] ??
-        Ref.fromJson(json['singleton'] as Map<String, dynamic>),
+    Ref.fromJson(json['singleton'] as Map<String, dynamic>),
   );
 }
 
@@ -178,8 +177,8 @@ Map<String, dynamic> _$SingletonToJson(Singleton instance) => <String, dynamic>{
 
 Take _$TakeFromJson(Map<String, dynamic> json) {
   return Take(
-    json['take'],
-    json['collection'],
+    json['take'] as Object,
+    json['collection'] as Object,
   );
 }
 
@@ -190,7 +189,7 @@ Map<String, dynamic> _$TakeToJson(Take instance) => <String, dynamic>{
 
 Union _$UnionFromJson(Map<String, dynamic> json) {
   return Union(
-    json['union'],
+    json['union'] as Object,
   );
 }
 

--- a/lib/src/fql/array_and_set.g.dart
+++ b/lib/src/fql/array_and_set.g.dart
@@ -53,9 +53,7 @@ Map<String, dynamic> _$DropToJson(Drop instance) => <String, dynamic>{
 Filter _$FilterFromJson(Map<String, dynamic> json) {
   return Filter(
     json['collection'],
-    json['filter'] == null
-        ? null
-        : Lambda.fromJson(json['filter'] as Map<String, dynamic>),
+    json['filter'] ?? Lambda.fromJson(json['filter'] as Map<String, dynamic>),
   );
 }
 
@@ -67,9 +65,7 @@ Map<String, dynamic> _$FilterToJson(Filter instance) => <String, dynamic>{
 Foreach _$ForeachFromJson(Map<String, dynamic> json) {
   return Foreach(
     json['foreach'],
-    json['lambda'] == null
-        ? null
-        : Lambda.fromJson(json['lambda'] as Map<String, dynamic>),
+    json['lambda'] ?? Lambda.fromJson(json['lambda'] as Map<String, dynamic>),
   );
 }
 
@@ -125,9 +121,7 @@ Map<String, dynamic> _$JoinToJson(Join instance) => <String, dynamic>{
 Map_ _$Map_FromJson(Map<String, dynamic> json) {
   return Map_(
     json['collection'],
-    json['map'] == null
-        ? null
-        : Lambda.fromJson(json['map'] as Map<String, dynamic>),
+    json['map'] ?? Lambda.fromJson(json['map'] as Map<String, dynamic>),
   );
 }
 
@@ -173,9 +167,8 @@ Map<String, dynamic> _$PrependToJson(Prepend instance) => <String, dynamic>{
 
 Singleton _$SingletonFromJson(Map<String, dynamic> json) {
   return Singleton(
-    json['singleton'] == null
-        ? null
-        : Ref.fromJson(json['singleton'] as Map<String, dynamic>),
+    json['singleton'] ??
+        Ref.fromJson(json['singleton'] as Map<String, dynamic>),
   );
 }
 

--- a/lib/src/fql/authentication.dart
+++ b/lib/src/fql/authentication.dart
@@ -89,7 +89,7 @@ class Identity extends Expr {
 @JsonSerializable()
 class Keys extends Expr {
   @JsonKey(name: 'keys', includeIfNull: true)
-  final Object database;
+  final Object? database;
 
   Keys({this.database});
 
@@ -118,7 +118,7 @@ class Login extends Expr {
 @JsonSerializable()
 class Logout extends Expr {
   @JsonKey(name: 'logout', includeIfNull: true)
-  final bool all_tokens;
+  final bool? all_tokens;
 
   Logout({this.all_tokens});
 

--- a/lib/src/fql/authentication.g.dart
+++ b/lib/src/fql/authentication.g.dart
@@ -28,9 +28,7 @@ HasIdentity _$HasIdentityFromJson(Map<String, dynamic> json) {
 
 Identify _$IdentifyFromJson(Map<String, dynamic> json) {
   return Identify(
-    json['identity'] == null
-        ? null
-        : Ref.fromJson(json['identity'] as Map<String, dynamic>),
+    json['identity'] ?? Ref.fromJson(json['identity'] as Map<String, dynamic>),
     json['password'] as String,
   );
 }
@@ -57,9 +55,7 @@ Map<String, dynamic> _$KeysToJson(Keys instance) => <String, dynamic>{
 Login _$LoginFromJson(Map<String, dynamic> json) {
   return Login(
     json['login'],
-    json['params'] == null
-        ? null
-        : Obj.fromJson(json['params'] as Map<String, dynamic>),
+    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 

--- a/lib/src/fql/authentication.g.dart
+++ b/lib/src/fql/authentication.g.dart
@@ -28,7 +28,7 @@ HasIdentity _$HasIdentityFromJson(Map<String, dynamic> json) {
 
 Identify _$IdentifyFromJson(Map<String, dynamic> json) {
   return Identify(
-    json['identity'] ?? Ref.fromJson(json['identity'] as Map<String, dynamic>),
+    Ref.fromJson(json['identity'] as Map<String, dynamic>),
     json['password'] as String,
   );
 }
@@ -54,8 +54,8 @@ Map<String, dynamic> _$KeysToJson(Keys instance) => <String, dynamic>{
 
 Login _$LoginFromJson(Map<String, dynamic> json) {
   return Login(
-    json['login'],
-    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
+    json['login'] as Object,
+    Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 
@@ -66,7 +66,7 @@ Map<String, dynamic> _$LoginToJson(Login instance) => <String, dynamic>{
 
 Logout _$LogoutFromJson(Map<String, dynamic> json) {
   return Logout(
-    all_tokens: json['logout'] as bool,
+    all_tokens: json['logout'] as bool?,
   );
 }
 

--- a/lib/src/fql/basic.dart
+++ b/lib/src/fql/basic.dart
@@ -27,7 +27,7 @@ class Call extends Expr {
   final Object function;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object arguments;
+  final Object? arguments;
 
   Call(this.function, {this.arguments});
 

--- a/lib/src/fql/basic.g.dart
+++ b/lib/src/fql/basic.g.dart
@@ -8,8 +8,8 @@ part of 'basic.dart';
 
 At _$AtFromJson(Map<String, dynamic> json) {
   return At(
-    json['at'] ?? Time.fromJson(json['at'] as Map<String, dynamic>),
-    json['expr'] ?? Expr.fromJson(json['expr'] as Map<String, dynamic>),
+    Time.fromJson(json['at'] as Map<String, dynamic>),
+    Expr.fromJson(json['expr'] as Map<String, dynamic>),
   );
 }
 
@@ -21,7 +21,7 @@ Map<String, dynamic> _$AtToJson(At instance) => <String, dynamic>{
 Call _$CallFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['arguments']);
   return Call(
-    json['call'],
+    json['call'] as Object,
     arguments: json['arguments'],
   );
 }
@@ -43,7 +43,7 @@ Map<String, dynamic> _$CallToJson(Call instance) {
 
 Do _$DoFromJson(Map<String, dynamic> json) {
   return Do(
-    json['do'] as List,
+    json['do'] as List<dynamic>,
   );
 }
 
@@ -53,9 +53,9 @@ Map<String, dynamic> _$DoToJson(Do instance) => <String, dynamic>{
 
 If _$IfFromJson(Map<String, dynamic> json) {
   return If(
-    json['if'],
-    json['then'],
-    json['else'],
+    json['if'] as Object,
+    json['then'] as Object,
+    json['else'] as Object,
   );
 }
 
@@ -67,8 +67,8 @@ Map<String, dynamic> _$IfToJson(If instance) => <String, dynamic>{
 
 Lambda _$LambdaFromJson(Map<String, dynamic> json) {
   return Lambda(
-    json['lambda'],
-    json['expr'] ?? Expr.fromJson(json['expr'] as Map<String, dynamic>),
+    json['lambda'] as Object,
+    Expr.fromJson(json['expr'] as Map<String, dynamic>),
   );
 }
 
@@ -80,7 +80,7 @@ Map<String, dynamic> _$LambdaToJson(Lambda instance) => <String, dynamic>{
 Let _$LetFromJson(Map<String, dynamic> json) {
   return Let(
     json['let'] as Map<String, dynamic>,
-    json['in'] ?? Expr.fromJson(json['in'] as Map<String, dynamic>),
+    Expr.fromJson(json['in'] as Map<String, dynamic>),
   );
 }
 

--- a/lib/src/fql/basic.g.dart
+++ b/lib/src/fql/basic.g.dart
@@ -8,12 +8,8 @@ part of 'basic.dart';
 
 At _$AtFromJson(Map<String, dynamic> json) {
   return At(
-    json['at'] == null
-        ? null
-        : Time.fromJson(json['at'] as Map<String, dynamic>),
-    json['expr'] == null
-        ? null
-        : Expr.fromJson(json['expr'] as Map<String, dynamic>),
+    json['at'] ?? Time.fromJson(json['at'] as Map<String, dynamic>),
+    json['expr'] ?? Expr.fromJson(json['expr'] as Map<String, dynamic>),
   );
 }
 
@@ -72,9 +68,7 @@ Map<String, dynamic> _$IfToJson(If instance) => <String, dynamic>{
 Lambda _$LambdaFromJson(Map<String, dynamic> json) {
   return Lambda(
     json['lambda'],
-    json['expr'] == null
-        ? null
-        : Expr.fromJson(json['expr'] as Map<String, dynamic>),
+    json['expr'] ?? Expr.fromJson(json['expr'] as Map<String, dynamic>),
   );
 }
 
@@ -86,9 +80,7 @@ Map<String, dynamic> _$LambdaToJson(Lambda instance) => <String, dynamic>{
 Let _$LetFromJson(Map<String, dynamic> json) {
   return Let(
     json['let'] as Map<String, dynamic>,
-    json['in'] == null
-        ? null
-        : Expr.fromJson(json['in'] as Map<String, dynamic>),
+    json['in'] ?? Expr.fromJson(json['in'] as Map<String, dynamic>),
   );
 }
 

--- a/lib/src/fql/conversion.g.dart
+++ b/lib/src/fql/conversion.g.dart
@@ -8,7 +8,7 @@ part of 'conversion.dart';
 
 ToArray _$ToArrayFromJson(Map<String, dynamic> json) {
   return ToArray(
-    json['to_array'],
+    json['to_array'] as Object,
   );
 }
 
@@ -18,7 +18,7 @@ Map<String, dynamic> _$ToArrayToJson(ToArray instance) => <String, dynamic>{
 
 ToDate _$ToDateFromJson(Map<String, dynamic> json) {
   return ToDate(
-    json['to_date'],
+    json['to_date'] as Object,
   );
 }
 
@@ -28,7 +28,7 @@ Map<String, dynamic> _$ToDateToJson(ToDate instance) => <String, dynamic>{
 
 ToDouble _$ToDoubleFromJson(Map<String, dynamic> json) {
   return ToDouble(
-    json['to_double'],
+    json['to_double'] as Object,
   );
 }
 
@@ -38,7 +38,7 @@ Map<String, dynamic> _$ToDoubleToJson(ToDouble instance) => <String, dynamic>{
 
 ToInteger _$ToIntegerFromJson(Map<String, dynamic> json) {
   return ToInteger(
-    json['to_integer'],
+    json['to_integer'] as Object,
   );
 }
 
@@ -48,7 +48,7 @@ Map<String, dynamic> _$ToIntegerToJson(ToInteger instance) => <String, dynamic>{
 
 ToMicros _$ToMicrosFromJson(Map<String, dynamic> json) {
   return ToMicros(
-    json['to_micros'],
+    json['to_micros'] as Object,
   );
 }
 
@@ -58,7 +58,7 @@ Map<String, dynamic> _$ToMicrosToJson(ToMicros instance) => <String, dynamic>{
 
 ToMillis _$ToMillisFromJson(Map<String, dynamic> json) {
   return ToMillis(
-    json['to_millis'],
+    json['to_millis'] as Object,
   );
 }
 
@@ -68,7 +68,7 @@ Map<String, dynamic> _$ToMillisToJson(ToMillis instance) => <String, dynamic>{
 
 ToNumber _$ToNumberFromJson(Map<String, dynamic> json) {
   return ToNumber(
-    json['to_number'],
+    json['to_number'] as Object,
   );
 }
 
@@ -78,7 +78,7 @@ Map<String, dynamic> _$ToNumberToJson(ToNumber instance) => <String, dynamic>{
 
 ToObject _$ToObjectFromJson(Map<String, dynamic> json) {
   return ToObject(
-    json['to_object'],
+    json['to_object'] as Object,
   );
 }
 
@@ -88,7 +88,7 @@ Map<String, dynamic> _$ToObjectToJson(ToObject instance) => <String, dynamic>{
 
 ToSeconds _$ToSecondsFromJson(Map<String, dynamic> json) {
   return ToSeconds(
-    json['to_seconds'],
+    json['to_seconds'] as Object,
   );
 }
 
@@ -98,7 +98,7 @@ Map<String, dynamic> _$ToSecondsToJson(ToSeconds instance) => <String, dynamic>{
 
 ToString _$ToStringFromJson(Map<String, dynamic> json) {
   return ToString(
-    json['to_string'],
+    json['to_string'] as Object,
   );
 }
 
@@ -108,7 +108,7 @@ Map<String, dynamic> _$ToStringToJson(ToString instance) => <String, dynamic>{
 
 ToTime _$ToTimeFromJson(Map<String, dynamic> json) {
   return ToTime(
-    json['to_time'],
+    json['to_time'] as Object,
   );
 }
 

--- a/lib/src/fql/expr.dart
+++ b/lib/src/fql/expr.dart
@@ -8,7 +8,7 @@ part 'expr.g.dart';
 
 @JsonSerializable()
 class Expr {
-  static Object wrap_value(dynamic value) {
+  static Object? wrap_value(dynamic value) {
     if (value is List) {
       return wrap_values(value);
     } else if (value is Map<String, dynamic>) {
@@ -20,7 +20,7 @@ class Expr {
     }
   }
 
-  static Object wrap_values(Object data) {
+  static Object? wrap_values(Object? data) {
     if (data == null) return null;
 
     if (data is List) {

--- a/lib/src/fql/expr.dart
+++ b/lib/src/fql/expr.dart
@@ -68,6 +68,6 @@ class Obj extends Expr {
 
   @override
   String toString() {
-    return 'Obj(${object})';
+    return 'Obj($object)';
   }
 }

--- a/lib/src/fql/expr.dart
+++ b/lib/src/fql/expr.dart
@@ -57,7 +57,7 @@ class Obj extends Expr {
     fromJson: Result.unwrap_values,
     toJson: Expr.wrap_values,
   )
-  final Object object;
+  final Object? object;
 
   Obj(this.object);
 

--- a/lib/src/fql/expr.g.dart
+++ b/lib/src/fql/expr.g.dart
@@ -15,7 +15,7 @@ Map<String, dynamic> _$ExprToJson(Expr instance) => <String, dynamic>{};
 Obj _$ObjFromJson(Map<String, dynamic> json) {
   $checkKeys(json, requiredKeys: const ['object']);
   return Obj(
-    Result.unwrap_values(json['object'])!,
+    Result.unwrap_values(json['object']),
   );
 }
 

--- a/lib/src/fql/expr.g.dart
+++ b/lib/src/fql/expr.g.dart
@@ -15,7 +15,7 @@ Map<String, dynamic> _$ExprToJson(Expr instance) => <String, dynamic>{};
 Obj _$ObjFromJson(Map<String, dynamic> json) {
   $checkKeys(json, requiredKeys: const ['object']);
   return Obj(
-    Result.unwrap_values(json['object']),
+    Result.unwrap_values(json['object'])!,
   );
 }
 

--- a/lib/src/fql/logic.dart
+++ b/lib/src/fql/logic.dart
@@ -53,7 +53,7 @@ class Exists extends Expr {
   final Object ref;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object ts;
+  final Object? ts;
 
   Exists(this.ref, {this.ts});
 

--- a/lib/src/fql/logic.g.dart
+++ b/lib/src/fql/logic.g.dart
@@ -8,7 +8,7 @@ part of 'logic.dart';
 
 And _$AndFromJson(Map<String, dynamic> json) {
   return And(
-    json['and'],
+    json['and'] as Object,
   );
 }
 
@@ -18,8 +18,8 @@ Map<String, dynamic> _$AndToJson(And instance) => <String, dynamic>{
 
 Contains _$ContainsFromJson(Map<String, dynamic> json) {
   return Contains(
-    json['contains'],
-    json['in'],
+    json['contains'] as Object,
+    json['in'] as Object,
   );
 }
 
@@ -30,7 +30,7 @@ Map<String, dynamic> _$ContainsToJson(Contains instance) => <String, dynamic>{
 
 Equals _$EqualsFromJson(Map<String, dynamic> json) {
   return Equals(
-    json['equals'],
+    json['equals'] as Object,
   );
 }
 
@@ -41,7 +41,7 @@ Map<String, dynamic> _$EqualsToJson(Equals instance) => <String, dynamic>{
 Exists _$ExistsFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['ts']);
   return Exists(
-    json['exists'],
+    json['exists'] as Object,
     ts: json['ts'],
   );
 }
@@ -63,7 +63,7 @@ Map<String, dynamic> _$ExistsToJson(Exists instance) {
 
 GT _$GTFromJson(Map<String, dynamic> json) {
   return GT(
-    json['gt'],
+    json['gt'] as Object,
   );
 }
 
@@ -73,7 +73,7 @@ Map<String, dynamic> _$GTToJson(GT instance) => <String, dynamic>{
 
 GTE _$GTEFromJson(Map<String, dynamic> json) {
   return GTE(
-    json['gte'],
+    json['gte'] as Object,
   );
 }
 
@@ -83,7 +83,7 @@ Map<String, dynamic> _$GTEToJson(GTE instance) => <String, dynamic>{
 
 LT _$LTFromJson(Map<String, dynamic> json) {
   return LT(
-    json['lt'],
+    json['lt'] as Object,
   );
 }
 
@@ -93,7 +93,7 @@ Map<String, dynamic> _$LTToJson(LT instance) => <String, dynamic>{
 
 LTE _$LTEFromJson(Map<String, dynamic> json) {
   return LTE(
-    json['lte'],
+    json['lte'] as Object,
   );
 }
 
@@ -103,7 +103,7 @@ Map<String, dynamic> _$LTEToJson(LTE instance) => <String, dynamic>{
 
 Not _$NotFromJson(Map<String, dynamic> json) {
   return Not(
-    json['not'],
+    json['not'] as Object,
   );
 }
 
@@ -113,7 +113,7 @@ Map<String, dynamic> _$NotToJson(Not instance) => <String, dynamic>{
 
 Or _$OrFromJson(Map<String, dynamic> json) {
   return Or(
-    json['or'],
+    json['or'] as Object,
   );
 }
 

--- a/lib/src/fql/math.dart
+++ b/lib/src/fql/math.dart
@@ -219,7 +219,7 @@ class Hypot extends Expr {
   final Object a;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object b;
+  final Object? b;
 
   Hypot(this.a, {this.b});
 
@@ -357,7 +357,7 @@ class Round extends Expr {
   final Object value;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object precision;
+  final Object? precision;
 
   Round(this.value, {this.precision});
 
@@ -478,7 +478,7 @@ class Trunc extends Expr {
   final Object value;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object precision;
+  final Object? precision;
 
   Trunc(this.value, {this.precision});
 

--- a/lib/src/fql/math.g.dart
+++ b/lib/src/fql/math.g.dart
@@ -8,7 +8,7 @@ part of 'math.dart';
 
 Abs _$AbsFromJson(Map<String, dynamic> json) {
   return Abs(
-    json['abs'],
+    json['abs'] as Object,
   );
 }
 
@@ -18,7 +18,7 @@ Map<String, dynamic> _$AbsToJson(Abs instance) => <String, dynamic>{
 
 Acos _$AcosFromJson(Map<String, dynamic> json) {
   return Acos(
-    json['acos'],
+    json['acos'] as Object,
   );
 }
 
@@ -28,7 +28,7 @@ Map<String, dynamic> _$AcosToJson(Acos instance) => <String, dynamic>{
 
 Add _$AddFromJson(Map<String, dynamic> json) {
   return Add(
-    json['add'],
+    json['add'] as Object,
   );
 }
 
@@ -38,7 +38,7 @@ Map<String, dynamic> _$AddToJson(Add instance) => <String, dynamic>{
 
 Asin _$AsinFromJson(Map<String, dynamic> json) {
   return Asin(
-    json['asin'],
+    json['asin'] as Object,
   );
 }
 
@@ -48,7 +48,7 @@ Map<String, dynamic> _$AsinToJson(Asin instance) => <String, dynamic>{
 
 Atan _$AtanFromJson(Map<String, dynamic> json) {
   return Atan(
-    json['atan'],
+    json['atan'] as Object,
   );
 }
 
@@ -58,7 +58,7 @@ Map<String, dynamic> _$AtanToJson(Atan instance) => <String, dynamic>{
 
 BitAnd _$BitAndFromJson(Map<String, dynamic> json) {
   return BitAnd(
-    json['bitand'],
+    json['bitand'] as Object,
   );
 }
 
@@ -68,7 +68,7 @@ Map<String, dynamic> _$BitAndToJson(BitAnd instance) => <String, dynamic>{
 
 BitNot _$BitNotFromJson(Map<String, dynamic> json) {
   return BitNot(
-    json['bitnot'],
+    json['bitnot'] as Object,
   );
 }
 
@@ -78,7 +78,7 @@ Map<String, dynamic> _$BitNotToJson(BitNot instance) => <String, dynamic>{
 
 BitOr _$BitOrFromJson(Map<String, dynamic> json) {
   return BitOr(
-    json['bitor'],
+    json['bitor'] as Object,
   );
 }
 
@@ -88,7 +88,7 @@ Map<String, dynamic> _$BitOrToJson(BitOr instance) => <String, dynamic>{
 
 BitXor _$BitXorFromJson(Map<String, dynamic> json) {
   return BitXor(
-    json['bitxor'],
+    json['bitxor'] as Object,
   );
 }
 
@@ -98,7 +98,7 @@ Map<String, dynamic> _$BitXorToJson(BitXor instance) => <String, dynamic>{
 
 Ceil _$CeilFromJson(Map<String, dynamic> json) {
   return Ceil(
-    json['ceil'],
+    json['ceil'] as Object,
   );
 }
 
@@ -108,7 +108,7 @@ Map<String, dynamic> _$CeilToJson(Ceil instance) => <String, dynamic>{
 
 Cos _$CosFromJson(Map<String, dynamic> json) {
   return Cos(
-    json['cos'],
+    json['cos'] as Object,
   );
 }
 
@@ -118,7 +118,7 @@ Map<String, dynamic> _$CosToJson(Cos instance) => <String, dynamic>{
 
 Cosh _$CoshFromJson(Map<String, dynamic> json) {
   return Cosh(
-    json['cosh'],
+    json['cosh'] as Object,
   );
 }
 
@@ -128,7 +128,7 @@ Map<String, dynamic> _$CoshToJson(Cosh instance) => <String, dynamic>{
 
 Degrees _$DegreesFromJson(Map<String, dynamic> json) {
   return Degrees(
-    json['degrees'],
+    json['degrees'] as Object,
   );
 }
 
@@ -138,7 +138,7 @@ Map<String, dynamic> _$DegreesToJson(Degrees instance) => <String, dynamic>{
 
 Divide _$DivideFromJson(Map<String, dynamic> json) {
   return Divide(
-    json['divide'],
+    json['divide'] as Object,
   );
 }
 
@@ -148,7 +148,7 @@ Map<String, dynamic> _$DivideToJson(Divide instance) => <String, dynamic>{
 
 Exp _$ExpFromJson(Map<String, dynamic> json) {
   return Exp(
-    json['exp'],
+    json['exp'] as Object,
   );
 }
 
@@ -158,7 +158,7 @@ Map<String, dynamic> _$ExpToJson(Exp instance) => <String, dynamic>{
 
 Floor _$FloorFromJson(Map<String, dynamic> json) {
   return Floor(
-    json['floor'],
+    json['floor'] as Object,
   );
 }
 
@@ -169,7 +169,7 @@ Map<String, dynamic> _$FloorToJson(Floor instance) => <String, dynamic>{
 Hypot _$HypotFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['b']);
   return Hypot(
-    json['hypot'],
+    json['hypot'] as Object,
     b: json['b'],
   );
 }
@@ -191,7 +191,7 @@ Map<String, dynamic> _$HypotToJson(Hypot instance) {
 
 Ln _$LnFromJson(Map<String, dynamic> json) {
   return Ln(
-    json['ln'],
+    json['ln'] as Object,
   );
 }
 
@@ -201,7 +201,7 @@ Map<String, dynamic> _$LnToJson(Ln instance) => <String, dynamic>{
 
 Log _$LogFromJson(Map<String, dynamic> json) {
   return Log(
-    json['log'],
+    json['log'] as Object,
   );
 }
 
@@ -211,7 +211,7 @@ Map<String, dynamic> _$LogToJson(Log instance) => <String, dynamic>{
 
 Max _$MaxFromJson(Map<String, dynamic> json) {
   return Max(
-    json['max'],
+    json['max'] as Object,
   );
 }
 
@@ -221,7 +221,7 @@ Map<String, dynamic> _$MaxToJson(Max instance) => <String, dynamic>{
 
 Mean _$MeanFromJson(Map<String, dynamic> json) {
   return Mean(
-    json['mean'],
+    json['mean'] as Object,
   );
 }
 
@@ -231,7 +231,7 @@ Map<String, dynamic> _$MeanToJson(Mean instance) => <String, dynamic>{
 
 Min _$MinFromJson(Map<String, dynamic> json) {
   return Min(
-    json['min'],
+    json['min'] as Object,
   );
 }
 
@@ -241,7 +241,7 @@ Map<String, dynamic> _$MinToJson(Min instance) => <String, dynamic>{
 
 Modulo _$ModuloFromJson(Map<String, dynamic> json) {
   return Modulo(
-    json['modulo'],
+    json['modulo'] as Object,
   );
 }
 
@@ -251,7 +251,7 @@ Map<String, dynamic> _$ModuloToJson(Modulo instance) => <String, dynamic>{
 
 Multiply _$MultiplyFromJson(Map<String, dynamic> json) {
   return Multiply(
-    json['multiply'],
+    json['multiply'] as Object,
   );
 }
 
@@ -261,8 +261,8 @@ Map<String, dynamic> _$MultiplyToJson(Multiply instance) => <String, dynamic>{
 
 Pow _$PowFromJson(Map<String, dynamic> json) {
   return Pow(
-    json['pow'],
-    json['exp'],
+    json['pow'] as Object,
+    json['exp'] as Object,
   );
 }
 
@@ -273,7 +273,7 @@ Map<String, dynamic> _$PowToJson(Pow instance) => <String, dynamic>{
 
 Radians _$RadiansFromJson(Map<String, dynamic> json) {
   return Radians(
-    json['radians'],
+    json['radians'] as Object,
   );
 }
 
@@ -284,7 +284,7 @@ Map<String, dynamic> _$RadiansToJson(Radians instance) => <String, dynamic>{
 Round _$RoundFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['precision']);
   return Round(
-    json['round'],
+    json['round'] as Object,
     precision: json['precision'],
   );
 }
@@ -306,7 +306,7 @@ Map<String, dynamic> _$RoundToJson(Round instance) {
 
 Sign _$SignFromJson(Map<String, dynamic> json) {
   return Sign(
-    json['sign'],
+    json['sign'] as Object,
   );
 }
 
@@ -316,7 +316,7 @@ Map<String, dynamic> _$SignToJson(Sign instance) => <String, dynamic>{
 
 Sin _$SinFromJson(Map<String, dynamic> json) {
   return Sin(
-    json['sin'],
+    json['sin'] as Object,
   );
 }
 
@@ -326,7 +326,7 @@ Map<String, dynamic> _$SinToJson(Sin instance) => <String, dynamic>{
 
 Sinh _$SinhFromJson(Map<String, dynamic> json) {
   return Sinh(
-    json['sinh'],
+    json['sinh'] as Object,
   );
 }
 
@@ -336,7 +336,7 @@ Map<String, dynamic> _$SinhToJson(Sinh instance) => <String, dynamic>{
 
 Sqrt _$SqrtFromJson(Map<String, dynamic> json) {
   return Sqrt(
-    json['sqrt'],
+    json['sqrt'] as Object,
   );
 }
 
@@ -346,7 +346,7 @@ Map<String, dynamic> _$SqrtToJson(Sqrt instance) => <String, dynamic>{
 
 Subtract _$SubtractFromJson(Map<String, dynamic> json) {
   return Subtract(
-    json['subtract'],
+    json['subtract'] as Object,
   );
 }
 
@@ -356,7 +356,7 @@ Map<String, dynamic> _$SubtractToJson(Subtract instance) => <String, dynamic>{
 
 Sum _$SumFromJson(Map<String, dynamic> json) {
   return Sum(
-    json['sum'],
+    json['sum'] as Object,
   );
 }
 
@@ -366,7 +366,7 @@ Map<String, dynamic> _$SumToJson(Sum instance) => <String, dynamic>{
 
 Tan _$TanFromJson(Map<String, dynamic> json) {
   return Tan(
-    json['tan'],
+    json['tan'] as Object,
   );
 }
 
@@ -376,7 +376,7 @@ Map<String, dynamic> _$TanToJson(Tan instance) => <String, dynamic>{
 
 Tanh _$TanhFromJson(Map<String, dynamic> json) {
   return Tanh(
-    json['tanh'],
+    json['tanh'] as Object,
   );
 }
 
@@ -387,7 +387,7 @@ Map<String, dynamic> _$TanhToJson(Tanh instance) => <String, dynamic>{
 Trunc _$TruncFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['precision']);
   return Trunc(
-    json['trunc'],
+    json['trunc'] as Object,
     precision: json['precision'],
   );
 }

--- a/lib/src/fql/miscellaneous.dart
+++ b/lib/src/fql/miscellaneous.dart
@@ -24,7 +24,7 @@ class Collection extends Ref {
   final Object name;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object database;
+  final Object? database;
 
   Collection(this.name, {this.database}) : super.empty();
 
@@ -38,7 +38,7 @@ class Collection extends Ref {
 @JsonSerializable()
 class Collections extends Ref {
   @JsonKey(name: 'collections', includeIfNull: true)
-  final Object database;
+  final Object? database;
 
   Collections({this.database}) : super.empty();
 
@@ -55,7 +55,7 @@ class Database extends Ref {
   final Object name;
 
   @JsonKey(name: 'scope', disallowNullValue: true, includeIfNull: false)
-  final Ref database;
+  final Ref? database;
 
   Database(this.name, {this.database}) : super.empty();
 
@@ -69,7 +69,7 @@ class Database extends Ref {
 @JsonSerializable()
 class Databases extends Ref {
   @JsonKey(name: 'databases', includeIfNull: true)
-  final Object database;
+  final Object? database;
 
   Databases({this.database}) : super.empty();
 
@@ -100,7 +100,7 @@ class Function_ extends Ref {
   final String name;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Ref database;
+  final Ref? database;
 
   Function_(this.name, {this.database}) : super.empty();
 
@@ -114,7 +114,7 @@ class Function_ extends Ref {
 @JsonSerializable()
 class Functions extends Ref {
   @JsonKey(name: 'functions', includeIfNull: true)
-  final Ref database;
+  final Ref? database;
 
   Functions({this.database}) : super.empty();
 
@@ -131,7 +131,7 @@ class Index extends Ref {
   final Object name;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object database;
+  final Object? database;
 
   Index(this.name, {this.database}) : super.empty();
 
@@ -144,7 +144,7 @@ class Index extends Ref {
 @JsonSerializable()
 class Indexes extends Ref {
   @JsonKey(name: 'indexes', includeIfNull: true)
-  final Ref database;
+  final Ref? database;
 
   Indexes({this.database}) : super.empty();
 
@@ -181,9 +181,9 @@ class Query extends Expr {
 @JsonSerializable()
 class Ref extends Expr {
   @JsonKey(name: 'ref')
-  final Expr schema_ref;
+  final Expr? schema_ref;
 
-  final String id;
+  final String? id;
 
   Ref(this.schema_ref, this.id);
 
@@ -201,7 +201,7 @@ class Role extends Expr {
   final String name;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object database;
+  final Object? database;
 
   Role(this.name, {this.database});
 
@@ -214,7 +214,7 @@ class Role extends Expr {
 @JsonSerializable()
 class Roles extends Expr {
   @JsonKey(name: 'roles', includeIfNull: true)
-  final Ref database;
+  final Ref? database;
 
   Roles({this.database});
 

--- a/lib/src/fql/miscellaneous.g.dart
+++ b/lib/src/fql/miscellaneous.g.dart
@@ -8,7 +8,7 @@ part of 'miscellaneous.dart';
 
 Abort _$AbortFromJson(Map<String, dynamic> json) {
   return Abort(
-    json['abort'],
+    json['abort'] as Object,
   );
 }
 
@@ -19,7 +19,7 @@ Map<String, dynamic> _$AbortToJson(Abort instance) => <String, dynamic>{
 Collection _$CollectionFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['database']);
   return Collection(
-    json['collection'],
+    json['collection'] as Object,
     database: json['database'],
   );
 }
@@ -53,7 +53,7 @@ Map<String, dynamic> _$CollectionsToJson(Collections instance) =>
 Database _$DatabaseFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['scope']);
   return Database(
-    json['database'],
+    json['database'] as Object,
     database: json['scope'] == null
         ? null
         : Ref.fromJson(json['scope'] as Map<String, dynamic>),
@@ -87,7 +87,7 @@ Map<String, dynamic> _$DatabasesToJson(Databases instance) => <String, dynamic>{
 
 Documents _$DocumentsFromJson(Map<String, dynamic> json) {
   return Documents(
-    json['documents'],
+    json['documents'] as Object,
   );
 }
 
@@ -135,7 +135,7 @@ Map<String, dynamic> _$FunctionsToJson(Functions instance) => <String, dynamic>{
 Index _$IndexFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['database']);
   return Index(
-    json['index'],
+    json['index'] as Object,
     database: json['database'],
   );
 }
@@ -173,7 +173,7 @@ NewId _$NewIdFromJson(Map<String, dynamic> json) {
 
 Query _$QueryFromJson(Map<String, dynamic> json) {
   return Query(
-    json['query'] ?? Lambda.fromJson(json['query'] as Map<String, dynamic>),
+    Lambda.fromJson(json['query'] as Map<String, dynamic>),
   );
 }
 
@@ -186,7 +186,7 @@ Ref _$RefFromJson(Map<String, dynamic> json) {
     json['ref'] == null
         ? null
         : Expr.fromJson(json['ref'] as Map<String, dynamic>),
-    json['id'] as String,
+    json['id'] as String?,
   );
 }
 

--- a/lib/src/fql/miscellaneous.g.dart
+++ b/lib/src/fql/miscellaneous.g.dart
@@ -173,9 +173,7 @@ NewId _$NewIdFromJson(Map<String, dynamic> json) {
 
 Query _$QueryFromJson(Map<String, dynamic> json) {
   return Query(
-    json['query'] == null
-        ? null
-        : Lambda.fromJson(json['query'] as Map<String, dynamic>),
+    json['query'] ?? Lambda.fromJson(json['query'] as Map<String, dynamic>),
   );
 }
 

--- a/lib/src/fql/page.dart
+++ b/lib/src/fql/page.dart
@@ -9,7 +9,8 @@ class Page {
 
   Page(this.before, this.after, this.data);
 
-  factory Page.fromResource({Object before, Object after, Object data}) {
+  factory Page.fromResource(
+      {required Object before, required Object after, required List data}) {
     var beforeCursor = before;
     if (before is List) {
       beforeCursor = List.from(before).map((element) {

--- a/lib/src/fql/read_and_write.dart
+++ b/lib/src/fql/read_and_write.dart
@@ -16,7 +16,7 @@ class Get extends Expr {
     includeIfNull: false,
     toJson: Expr.wrap_value,
   )
-  final DateTime ts;
+  final DateTime? ts;
 
   Get(this.ref, {this.ts});
 
@@ -50,7 +50,7 @@ class Paginate extends Expr {
     includeIfNull: false,
     toJson: Expr.wrap_value,
   )
-  final DateTime ts;
+  final DateTime? ts;
 
   @JsonKey(disallowNullValue: false, includeIfNull: true)
   final Object before;
@@ -59,13 +59,13 @@ class Paginate extends Expr {
   final Object after;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final int size;
+  final int? size;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final bool events;
+  final bool? events;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final bool sources;
+  final bool? sources;
 
   Paginate(
     this.input, {
@@ -101,7 +101,7 @@ class Select extends Expr {
   final Expr from;
 
   @JsonKey(name: 'default', disallowNullValue: true, includeIfNull: false)
-  final Expr default_;
+  final Expr? default_;
 
   Select(this.path, this.from, {this.default_});
 
@@ -266,7 +266,7 @@ class Merge extends Expr {
   final Object object2;
 
   @JsonKey(name: 'lambda', disallowNullValue: true, includeIfNull: false)
-  final Object customResolver;
+  final Object? customResolver;
 
   Merge(this.object1, this.object2, {this.customResolver});
 

--- a/lib/src/fql/read_and_write.g.dart
+++ b/lib/src/fql/read_and_write.g.dart
@@ -9,10 +9,8 @@ part of 'read_and_write.dart';
 Get _$GetFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['ts']);
   return Get(
-    json['get'] == null
-        ? null
-        : Expr.fromJson(json['get'] as Map<String, dynamic>),
-    ts: json['ts'] == null ? null : DateTime.parse(json['ts'] as String),
+    json['get'] ?? Expr.fromJson(json['get'] as Map<String, dynamic>),
+    ts: json['ts'] ?? DateTime.parse(json['ts'] as String),
   );
 }
 
@@ -46,10 +44,8 @@ Paginate _$PaginateFromJson(Map<String, dynamic> json) {
   $checkKeys(json,
       disallowNullValues: const ['ts', 'after', 'size', 'events', 'sources']);
   return Paginate(
-    json['paginate'] == null
-        ? null
-        : Expr.fromJson(json['paginate'] as Map<String, dynamic>),
-    ts: json['ts'] == null ? null : DateTime.parse(json['ts'] as String),
+    json['paginate'] ?? Expr.fromJson(json['paginate'] as Map<String, dynamic>),
+    ts: json['ts'] ?? DateTime.parse(json['ts'] as String),
     size: json['size'] as int,
     before: json['before'],
     after: json['after'],
@@ -82,12 +78,9 @@ Select _$SelectFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['default']);
   return Select(
     json['select'],
-    json['from'] == null
-        ? null
-        : Expr.fromJson(json['from'] as Map<String, dynamic>),
-    default_: json['default'] == null
-        ? null
-        : Expr.fromJson(json['default'] as Map<String, dynamic>),
+    json['from'] ?? Expr.fromJson(json['from'] as Map<String, dynamic>),
+    default_: json['default'] ??
+        Expr.fromJson(json['default'] as Map<String, dynamic>),
   );
 }
 
@@ -109,12 +102,8 @@ Map<String, dynamic> _$SelectToJson(Select instance) {
 
 Create _$CreateFromJson(Map<String, dynamic> json) {
   return Create(
-    json['create'] == null
-        ? null
-        : Expr.fromJson(json['create'] as Map<String, dynamic>),
-    json['params'] == null
-        ? null
-        : Obj.fromJson(json['params'] as Map<String, dynamic>),
+    json['create'] ?? Expr.fromJson(json['create'] as Map<String, dynamic>),
+    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 
@@ -125,9 +114,8 @@ Map<String, dynamic> _$CreateToJson(Create instance) => <String, dynamic>{
 
 CreateCollection _$CreateCollectionFromJson(Map<String, dynamic> json) {
   return CreateCollection(
-    json['create_collection'] == null
-        ? null
-        : Obj.fromJson(json['create_collection'] as Map<String, dynamic>),
+    json['create_collection'] ??
+        Obj.fromJson(json['create_collection'] as Map<String, dynamic>),
   );
 }
 
@@ -138,9 +126,8 @@ Map<String, dynamic> _$CreateCollectionToJson(CreateCollection instance) =>
 
 CreateDatabase _$CreateDatabaseFromJson(Map<String, dynamic> json) {
   return CreateDatabase(
-    json['create_database'] == null
-        ? null
-        : Obj.fromJson(json['create_database'] as Map<String, dynamic>),
+    json['create_database'] ??
+        Obj.fromJson(json['create_database'] as Map<String, dynamic>),
   );
 }
 
@@ -151,9 +138,8 @@ Map<String, dynamic> _$CreateDatabaseToJson(CreateDatabase instance) =>
 
 CreateFunction _$CreateFunctionFromJson(Map<String, dynamic> json) {
   return CreateFunction(
-    json['create_function'] == null
-        ? null
-        : Obj.fromJson(json['create_function'] as Map<String, dynamic>),
+    json['create_function'] ??
+        Obj.fromJson(json['create_function'] as Map<String, dynamic>),
   );
 }
 
@@ -164,9 +150,8 @@ Map<String, dynamic> _$CreateFunctionToJson(CreateFunction instance) =>
 
 CreateIndex _$CreateIndexFromJson(Map<String, dynamic> json) {
   return CreateIndex(
-    json['create_index'] == null
-        ? null
-        : Obj.fromJson(json['create_index'] as Map<String, dynamic>),
+    json['create_index'] ??
+        Obj.fromJson(json['create_index'] as Map<String, dynamic>),
   );
 }
 
@@ -177,9 +162,8 @@ Map<String, dynamic> _$CreateIndexToJson(CreateIndex instance) =>
 
 CreateKey _$CreateKeyFromJson(Map<String, dynamic> json) {
   return CreateKey(
-    json['create_key'] == null
-        ? null
-        : Obj.fromJson(json['create_key'] as Map<String, dynamic>),
+    json['create_key'] ??
+        Obj.fromJson(json['create_key'] as Map<String, dynamic>),
   );
 }
 
@@ -189,9 +173,8 @@ Map<String, dynamic> _$CreateKeyToJson(CreateKey instance) => <String, dynamic>{
 
 CreateRole _$CreateRoleFromJson(Map<String, dynamic> json) {
   return CreateRole(
-    json['create_role'] == null
-        ? null
-        : Obj.fromJson(json['create_role'] as Map<String, dynamic>),
+    json['create_role'] ??
+        Obj.fromJson(json['create_role'] as Map<String, dynamic>),
   );
 }
 
@@ -202,9 +185,7 @@ Map<String, dynamic> _$CreateRoleToJson(CreateRole instance) =>
 
 Delete _$DeleteFromJson(Map<String, dynamic> json) {
   return Delete(
-    json['delete'] == null
-        ? null
-        : Expr.fromJson(json['delete'] as Map<String, dynamic>),
+    json['delete'] ?? Expr.fromJson(json['delete'] as Map<String, dynamic>),
   );
 }
 
@@ -224,14 +205,10 @@ Map<String, dynamic> _$EventsToJson(Events instance) => <String, dynamic>{
 
 Insert _$InsertFromJson(Map<String, dynamic> json) {
   return Insert(
-    json['insert'] == null
-        ? null
-        : Ref.fromJson(json['insert'] as Map<String, dynamic>),
+    json['insert'] ?? Ref.fromJson(json['insert'] as Map<String, dynamic>),
     json['ts'],
     json['action'],
-    json['params'] == null
-        ? null
-        : Obj.fromJson(json['params'] as Map<String, dynamic>),
+    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 
@@ -269,9 +246,7 @@ Map<String, dynamic> _$MergeToJson(Merge instance) {
 
 Remove _$RemoveFromJson(Map<String, dynamic> json) {
   return Remove(
-    json['remove'] == null
-        ? null
-        : Expr.fromJson(json['remove'] as Map<String, dynamic>),
+    json['remove'] ?? Expr.fromJson(json['remove'] as Map<String, dynamic>),
     json['ts'],
     json['action'],
   );
@@ -285,12 +260,8 @@ Map<String, dynamic> _$RemoveToJson(Remove instance) => <String, dynamic>{
 
 Replace _$ReplaceFromJson(Map<String, dynamic> json) {
   return Replace(
-    json['replace'] == null
-        ? null
-        : Expr.fromJson(json['replace'] as Map<String, dynamic>),
-    json['params'] == null
-        ? null
-        : Obj.fromJson(json['params'] as Map<String, dynamic>),
+    json['replace'] ?? Expr.fromJson(json['replace'] as Map<String, dynamic>),
+    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 
@@ -301,12 +272,8 @@ Map<String, dynamic> _$ReplaceToJson(Replace instance) => <String, dynamic>{
 
 Update _$UpdateFromJson(Map<String, dynamic> json) {
   return Update(
-    json['update'] == null
-        ? null
-        : Expr.fromJson(json['update'] as Map<String, dynamic>),
-    json['params'] == null
-        ? null
-        : Obj.fromJson(json['params'] as Map<String, dynamic>),
+    json['update'] ?? Expr.fromJson(json['update'] as Map<String, dynamic>),
+    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 

--- a/lib/src/fql/read_and_write.g.dart
+++ b/lib/src/fql/read_and_write.g.dart
@@ -9,8 +9,8 @@ part of 'read_and_write.dart';
 Get _$GetFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['ts']);
   return Get(
-    json['get'] ?? Expr.fromJson(json['get'] as Map<String, dynamic>),
-    ts: json['ts'] ?? DateTime.parse(json['ts'] as String),
+    Expr.fromJson(json['get'] as Map<String, dynamic>),
+    ts: json['ts'] == null ? null : DateTime.parse(json['ts'] as String),
   );
 }
 
@@ -44,13 +44,13 @@ Paginate _$PaginateFromJson(Map<String, dynamic> json) {
   $checkKeys(json,
       disallowNullValues: const ['ts', 'after', 'size', 'events', 'sources']);
   return Paginate(
-    json['paginate'] ?? Expr.fromJson(json['paginate'] as Map<String, dynamic>),
-    ts: json['ts'] ?? DateTime.parse(json['ts'] as String),
-    size: json['size'] as int,
-    before: json['before'],
-    after: json['after'],
-    events: json['events'] as bool,
-    sources: json['sources'] as bool,
+    Expr.fromJson(json['paginate'] as Map<String, dynamic>),
+    ts: json['ts'] == null ? null : DateTime.parse(json['ts'] as String),
+    size: json['size'] as int?,
+    before: json['before'] as Object,
+    after: json['after'] as Object,
+    events: json['events'] as bool?,
+    sources: json['sources'] as bool?,
   );
 }
 
@@ -67,7 +67,7 @@ Map<String, dynamic> _$PaginateToJson(Paginate instance) {
 
   writeNotNull('ts', Expr.wrap_value(instance.ts));
   val['before'] = instance.before;
-  writeNotNull('after', instance.after);
+  val['after'] = instance.after;
   writeNotNull('size', instance.size);
   writeNotNull('events', instance.events);
   writeNotNull('sources', instance.sources);
@@ -77,10 +77,11 @@ Map<String, dynamic> _$PaginateToJson(Paginate instance) {
 Select _$SelectFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['default']);
   return Select(
-    json['select'],
-    json['from'] ?? Expr.fromJson(json['from'] as Map<String, dynamic>),
-    default_: json['default'] ??
-        Expr.fromJson(json['default'] as Map<String, dynamic>),
+    json['select'] as Object,
+    Expr.fromJson(json['from'] as Map<String, dynamic>),
+    default_: json['default'] == null
+        ? null
+        : Expr.fromJson(json['default'] as Map<String, dynamic>),
   );
 }
 
@@ -102,8 +103,8 @@ Map<String, dynamic> _$SelectToJson(Select instance) {
 
 Create _$CreateFromJson(Map<String, dynamic> json) {
   return Create(
-    json['create'] ?? Expr.fromJson(json['create'] as Map<String, dynamic>),
-    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
+    Expr.fromJson(json['create'] as Map<String, dynamic>),
+    Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 
@@ -114,8 +115,7 @@ Map<String, dynamic> _$CreateToJson(Create instance) => <String, dynamic>{
 
 CreateCollection _$CreateCollectionFromJson(Map<String, dynamic> json) {
   return CreateCollection(
-    json['create_collection'] ??
-        Obj.fromJson(json['create_collection'] as Map<String, dynamic>),
+    Obj.fromJson(json['create_collection'] as Map<String, dynamic>),
   );
 }
 
@@ -126,8 +126,7 @@ Map<String, dynamic> _$CreateCollectionToJson(CreateCollection instance) =>
 
 CreateDatabase _$CreateDatabaseFromJson(Map<String, dynamic> json) {
   return CreateDatabase(
-    json['create_database'] ??
-        Obj.fromJson(json['create_database'] as Map<String, dynamic>),
+    Obj.fromJson(json['create_database'] as Map<String, dynamic>),
   );
 }
 
@@ -138,8 +137,7 @@ Map<String, dynamic> _$CreateDatabaseToJson(CreateDatabase instance) =>
 
 CreateFunction _$CreateFunctionFromJson(Map<String, dynamic> json) {
   return CreateFunction(
-    json['create_function'] ??
-        Obj.fromJson(json['create_function'] as Map<String, dynamic>),
+    Obj.fromJson(json['create_function'] as Map<String, dynamic>),
   );
 }
 
@@ -150,8 +148,7 @@ Map<String, dynamic> _$CreateFunctionToJson(CreateFunction instance) =>
 
 CreateIndex _$CreateIndexFromJson(Map<String, dynamic> json) {
   return CreateIndex(
-    json['create_index'] ??
-        Obj.fromJson(json['create_index'] as Map<String, dynamic>),
+    Obj.fromJson(json['create_index'] as Map<String, dynamic>),
   );
 }
 
@@ -162,8 +159,7 @@ Map<String, dynamic> _$CreateIndexToJson(CreateIndex instance) =>
 
 CreateKey _$CreateKeyFromJson(Map<String, dynamic> json) {
   return CreateKey(
-    json['create_key'] ??
-        Obj.fromJson(json['create_key'] as Map<String, dynamic>),
+    Obj.fromJson(json['create_key'] as Map<String, dynamic>),
   );
 }
 
@@ -173,8 +169,7 @@ Map<String, dynamic> _$CreateKeyToJson(CreateKey instance) => <String, dynamic>{
 
 CreateRole _$CreateRoleFromJson(Map<String, dynamic> json) {
   return CreateRole(
-    json['create_role'] ??
-        Obj.fromJson(json['create_role'] as Map<String, dynamic>),
+    Obj.fromJson(json['create_role'] as Map<String, dynamic>),
   );
 }
 
@@ -185,7 +180,7 @@ Map<String, dynamic> _$CreateRoleToJson(CreateRole instance) =>
 
 Delete _$DeleteFromJson(Map<String, dynamic> json) {
   return Delete(
-    json['delete'] ?? Expr.fromJson(json['delete'] as Map<String, dynamic>),
+    Expr.fromJson(json['delete'] as Map<String, dynamic>),
   );
 }
 
@@ -195,7 +190,7 @@ Map<String, dynamic> _$DeleteToJson(Delete instance) => <String, dynamic>{
 
 Events _$EventsFromJson(Map<String, dynamic> json) {
   return Events(
-    json['events'],
+    json['events'] as Object,
   );
 }
 
@@ -205,10 +200,10 @@ Map<String, dynamic> _$EventsToJson(Events instance) => <String, dynamic>{
 
 Insert _$InsertFromJson(Map<String, dynamic> json) {
   return Insert(
-    json['insert'] ?? Ref.fromJson(json['insert'] as Map<String, dynamic>),
-    json['ts'],
-    json['action'],
-    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
+    Ref.fromJson(json['insert'] as Map<String, dynamic>),
+    json['ts'] as Object,
+    json['action'] as Object,
+    Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 
@@ -222,8 +217,8 @@ Map<String, dynamic> _$InsertToJson(Insert instance) => <String, dynamic>{
 Merge _$MergeFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['lambda']);
   return Merge(
-    json['merge'],
-    json['with'],
+    json['merge'] as Object,
+    json['with'] as Object,
     customResolver: json['lambda'],
   );
 }
@@ -246,9 +241,9 @@ Map<String, dynamic> _$MergeToJson(Merge instance) {
 
 Remove _$RemoveFromJson(Map<String, dynamic> json) {
   return Remove(
-    json['remove'] ?? Expr.fromJson(json['remove'] as Map<String, dynamic>),
-    json['ts'],
-    json['action'],
+    Expr.fromJson(json['remove'] as Map<String, dynamic>),
+    json['ts'] as Object,
+    json['action'] as Object,
   );
 }
 
@@ -260,8 +255,8 @@ Map<String, dynamic> _$RemoveToJson(Remove instance) => <String, dynamic>{
 
 Replace _$ReplaceFromJson(Map<String, dynamic> json) {
   return Replace(
-    json['replace'] ?? Expr.fromJson(json['replace'] as Map<String, dynamic>),
-    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
+    Expr.fromJson(json['replace'] as Map<String, dynamic>),
+    Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 
@@ -272,8 +267,8 @@ Map<String, dynamic> _$ReplaceToJson(Replace instance) => <String, dynamic>{
 
 Update _$UpdateFromJson(Map<String, dynamic> json) {
   return Update(
-    json['update'] ?? Expr.fromJson(json['update'] as Map<String, dynamic>),
-    json['params'] ?? Obj.fromJson(json['params'] as Map<String, dynamic>),
+    Expr.fromJson(json['update'] as Map<String, dynamic>),
+    Obj.fromJson(json['params'] as Map<String, dynamic>),
   );
 }
 

--- a/lib/src/fql/result.dart
+++ b/lib/src/fql/result.dart
@@ -9,7 +9,7 @@ import 'page.dart';
 part 'result.g.dart';
 
 class Result {
-  static Object _replace(
+  static Object? _replace(
     String key,
     Function constructor,
     Map<String, dynamic> data,
@@ -20,7 +20,7 @@ class Result {
     return null;
   }
 
-  static Object unwrap_value(String key, dynamic value) {
+  static Object? unwrap_value(String? key, dynamic value) {
     if (value is List) {
       return unwrap_values(value);
     } else if (value is Map<String, dynamic>) {
@@ -34,7 +34,7 @@ class Result {
     }
   }
 
-  static Object unwrap_values(Object data) {
+  static Object? unwrap_values(Object? data) {
     if (data == null) return null;
 
     if (data is List) {
@@ -84,17 +84,17 @@ class RefResult {
     fromJson: _unwrapCollection,
     includeIfNull: false,
   )
-  final RefResult collection;
+  final RefResult? collection;
 
-  static RefResult _unwrapCollection(collection) {
+  static RefResult? _unwrapCollection(collection) {
     if (collection == null) return null;
-    return Result.unwrap_values(collection);
+    return Result.unwrap_values(collection) as RefResult;
   }
 
   RefResult(this.id, this.collection);
 
   Ref asRef() {
-    return Ref(Collection(collection.id), id);
+    return Ref(Collection(collection!.id), id);
   }
 
   factory RefResult.fromJson(Map<String, dynamic> json) =>
@@ -105,9 +105,9 @@ class RefResult {
   @override
   String toString() {
     if (collection != null) {
-      return 'Ref(id: ${id}, collection: ${collection.toString()})';
+      return 'Ref(id: $id, collection: ${collection.toString()})';
     }
-    return 'Ref(id: ${id})';
+    return 'Ref(id: $id)';
   }
 }
 
@@ -117,7 +117,7 @@ class QueryResult {
   final Object params;
 
   @JsonKey(name: 'expr', fromJson: Result.unwrap_values)
-  final Object expression;
+  final Object? expression;
 
   QueryResult(this.params, this.expression);
 
@@ -128,24 +128,24 @@ class QueryResult {
 
   @override
   String toString() {
-    return 'Query(lambda: ${params}), expr: ${expression}';
+    return 'Query(lambda: $params), expr: $expression';
   }
 }
 
 @JsonSerializable()
 class FaunaResponse {
   @JsonKey(ignore: true)
-  String raw;
+  String? raw;
 
   @JsonKey(
     includeIfNull: false,
     fromJson: Result.unwrap_values,
     toJson: Expr.wrap_values,
   )
-  final Object resource;
+  final Object? resource;
 
-  @JsonKey(nullable: true, includeIfNull: false)
-  final List<Map<String, dynamic>> errors;
+  @JsonKey(includeIfNull: false)
+  final List<Map<String, dynamic>>? errors;
 
   bool get hasErrors => (errors != null);
 
@@ -153,7 +153,7 @@ class FaunaResponse {
 
   /// Convenience method to convert result to a Dart Map
   Map<String, dynamic> asMap() {
-    return json.decode(raw) as Map<String, dynamic>;
+    return json.decode(raw!) as Map<String, dynamic>;
   }
 
   /// Convenience method to build a Page object

--- a/lib/src/fql/result.g.dart
+++ b/lib/src/fql/result.g.dart
@@ -24,13 +24,13 @@ Map<String, dynamic> _$RefResultToJson(RefResult instance) {
     }
   }
 
-  writeNotNull('collection', instance.collection!.toJson());
+  writeNotNull('collection', instance.collection?.toJson());
   return val;
 }
 
 QueryResult _$QueryResultFromJson(Map<String, dynamic> json) {
   return QueryResult(
-    json['lambda'],
+    json['lambda'] as Object,
     Result.unwrap_values(json['expr']),
   );
 }
@@ -44,8 +44,9 @@ Map<String, dynamic> _$QueryResultToJson(QueryResult instance) =>
 FaunaResponse _$FaunaResponseFromJson(Map<String, dynamic> json) {
   return FaunaResponse(
     resource: Result.unwrap_values(json['resource']),
-    errors:
-        (json['errors'] as List).map((e) => e as Map<String, dynamic>).toList(),
+    errors: (json['errors'] as List<dynamic>?)
+        ?.map((e) => e as Map<String, dynamic>)
+        .toList(),
   );
 }
 

--- a/lib/src/fql/result.g.dart
+++ b/lib/src/fql/result.g.dart
@@ -24,7 +24,7 @@ Map<String, dynamic> _$RefResultToJson(RefResult instance) {
     }
   }
 
-  writeNotNull('collection', instance.collection?.toJson());
+  writeNotNull('collection', instance.collection!.toJson());
   return val;
 }
 
@@ -44,9 +44,8 @@ Map<String, dynamic> _$QueryResultToJson(QueryResult instance) =>
 FaunaResponse _$FaunaResponseFromJson(Map<String, dynamic> json) {
   return FaunaResponse(
     resource: Result.unwrap_values(json['resource']),
-    errors: (json['errors'] as List)
-        ?.map((e) => e as Map<String, dynamic>)
-        ?.toList(),
+    errors:
+        (json['errors'] as List).map((e) => e as Map<String, dynamic>).toList(),
   );
 }
 

--- a/lib/src/fql/string.dart
+++ b/lib/src/fql/string.dart
@@ -10,7 +10,7 @@ class Casefold extends Expr {
   final Object value;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final String normalizer;
+  final String? normalizer;
 
   Casefold(this.value, {this.normalizer});
 
@@ -27,7 +27,7 @@ class Concat extends Expr {
   final Object value;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final String seperator;
+  final String? seperator;
 
   Concat(this.value, {this.seperator});
 
@@ -45,7 +45,7 @@ class FindStr extends Expr {
   final Object find;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object start;
+  final Object? start;
 
   FindStr(this.value, this.find, {this.start});
 
@@ -65,10 +65,10 @@ class FindStrRegex extends Expr {
   final Object find;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object start;
+  final Object? start;
 
   @JsonKey(name: 'num_results', disallowNullValue: true, includeIfNull: false)
-  final Object max_results;
+  final Object? max_results;
 
   FindStrRegex(this.value, this.find, {this.start, this.max_results});
 
@@ -138,7 +138,7 @@ class Repeat extends Expr {
   final Object value;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object number;
+  final Object? number;
 
   Repeat(this.value, {this.number});
 
@@ -176,7 +176,7 @@ class ReplaceStrRegex extends Expr {
   final Object replace;
 
   @JsonKey(name: 'first', disallowNullValue: true, includeIfNull: false)
-  final Object first_only;
+  final Object? first_only;
 
   ReplaceStrRegex(this.value, this.pattern, this.replace, {this.first_only});
 
@@ -208,7 +208,7 @@ class SubString extends Expr {
   final Object start;
 
   @JsonKey(disallowNullValue: true, includeIfNull: false)
-  final Object length;
+  final Object? length;
 
   SubString(this.value, this.start, {this.length});
 

--- a/lib/src/fql/string.g.dart
+++ b/lib/src/fql/string.g.dart
@@ -9,8 +9,8 @@ part of 'string.dart';
 Casefold _$CasefoldFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['normalizer']);
   return Casefold(
-    json['casefold'],
-    normalizer: json['normalizer'] as String,
+    json['casefold'] as Object,
+    normalizer: json['normalizer'] as String?,
   );
 }
 
@@ -32,8 +32,8 @@ Map<String, dynamic> _$CasefoldToJson(Casefold instance) {
 Concat _$ConcatFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['seperator']);
   return Concat(
-    json['concat'],
-    seperator: json['seperator'] as String,
+    json['concat'] as Object,
+    seperator: json['seperator'] as String?,
   );
 }
 
@@ -55,8 +55,8 @@ Map<String, dynamic> _$ConcatToJson(Concat instance) {
 FindStr _$FindStrFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['start']);
   return FindStr(
-    json['findstr'],
-    json['find'],
+    json['findstr'] as Object,
+    json['find'] as Object,
     start: json['start'],
   );
 }
@@ -80,8 +80,8 @@ Map<String, dynamic> _$FindStrToJson(FindStr instance) {
 FindStrRegex _$FindStrRegexFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['start', 'num_results']);
   return FindStrRegex(
-    json['findstrregex'],
-    json['pattern'],
+    json['findstrregex'] as Object,
+    json['pattern'] as Object,
     start: json['start'],
     max_results: json['num_results'],
   );
@@ -106,7 +106,7 @@ Map<String, dynamic> _$FindStrRegexToJson(FindStrRegex instance) {
 
 LTrim _$LTrimFromJson(Map<String, dynamic> json) {
   return LTrim(
-    json['ltrim'],
+    json['ltrim'] as Object,
   );
 }
 
@@ -116,7 +116,7 @@ Map<String, dynamic> _$LTrimToJson(LTrim instance) => <String, dynamic>{
 
 Length _$LengthFromJson(Map<String, dynamic> json) {
   return Length(
-    json['length'],
+    json['length'] as Object,
   );
 }
 
@@ -126,7 +126,7 @@ Map<String, dynamic> _$LengthToJson(Length instance) => <String, dynamic>{
 
 LowerCase _$LowerCaseFromJson(Map<String, dynamic> json) {
   return LowerCase(
-    json['lowercase'],
+    json['lowercase'] as Object,
   );
 }
 
@@ -136,7 +136,7 @@ Map<String, dynamic> _$LowerCaseToJson(LowerCase instance) => <String, dynamic>{
 
 RTrim _$RTrimFromJson(Map<String, dynamic> json) {
   return RTrim(
-    json['rtrim'],
+    json['rtrim'] as Object,
   );
 }
 
@@ -147,7 +147,7 @@ Map<String, dynamic> _$RTrimToJson(RTrim instance) => <String, dynamic>{
 Repeat _$RepeatFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['number']);
   return Repeat(
-    json['repeat'],
+    json['repeat'] as Object,
     number: json['number'],
   );
 }
@@ -169,9 +169,9 @@ Map<String, dynamic> _$RepeatToJson(Repeat instance) {
 
 ReplaceStr _$ReplaceStrFromJson(Map<String, dynamic> json) {
   return ReplaceStr(
-    json['replacestr'],
-    json['find'],
-    json['replace'],
+    json['replacestr'] as Object,
+    json['find'] as Object,
+    json['replace'] as Object,
   );
 }
 
@@ -185,9 +185,9 @@ Map<String, dynamic> _$ReplaceStrToJson(ReplaceStr instance) =>
 ReplaceStrRegex _$ReplaceStrRegexFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['first']);
   return ReplaceStrRegex(
-    json['replacestrregex'],
-    json['pattern'],
-    json['replace'],
+    json['replacestrregex'] as Object,
+    json['pattern'] as Object,
+    json['replace'] as Object,
     first_only: json['first'],
   );
 }
@@ -211,7 +211,7 @@ Map<String, dynamic> _$ReplaceStrRegexToJson(ReplaceStrRegex instance) {
 
 Space _$SpaceFromJson(Map<String, dynamic> json) {
   return Space(
-    json['space'],
+    json['space'] as Object,
   );
 }
 
@@ -222,8 +222,8 @@ Map<String, dynamic> _$SpaceToJson(Space instance) => <String, dynamic>{
 SubString _$SubStringFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['length']);
   return SubString(
-    json['substring'],
-    json['start'],
+    json['substring'] as Object,
+    json['start'] as Object,
     length: json['length'],
   );
 }
@@ -246,7 +246,7 @@ Map<String, dynamic> _$SubStringToJson(SubString instance) {
 
 TitleCase _$TitleCaseFromJson(Map<String, dynamic> json) {
   return TitleCase(
-    json['titlecase'],
+    json['titlecase'] as Object,
   );
 }
 
@@ -256,7 +256,7 @@ Map<String, dynamic> _$TitleCaseToJson(TitleCase instance) => <String, dynamic>{
 
 Trim _$TrimFromJson(Map<String, dynamic> json) {
   return Trim(
-    json['trim'],
+    json['trim'] as Object,
   );
 }
 
@@ -266,7 +266,7 @@ Map<String, dynamic> _$TrimToJson(Trim instance) => <String, dynamic>{
 
 UpperCase _$UpperCaseFromJson(Map<String, dynamic> json) {
   return UpperCase(
-    json['uppercase'],
+    json['uppercase'] as Object,
   );
 }
 

--- a/lib/src/fql/time_and_date.g.dart
+++ b/lib/src/fql/time_and_date.g.dart
@@ -18,8 +18,7 @@ Map<String, dynamic> _$DateToJson(Date instance) => <String, dynamic>{
 
 DayOfMonth _$DayOfMonthFromJson(Map<String, dynamic> json) {
   return DayOfMonth(
-    json['day_of_month'] ??
-        Expr.fromJson(json['day_of_month'] as Map<String, dynamic>),
+    Expr.fromJson(json['day_of_month'] as Map<String, dynamic>),
   );
 }
 
@@ -30,8 +29,7 @@ Map<String, dynamic> _$DayOfMonthToJson(DayOfMonth instance) =>
 
 DayOfWeek _$DayOfWeekFromJson(Map<String, dynamic> json) {
   return DayOfWeek(
-    json['day_of_week'] ??
-        Expr.fromJson(json['day_of_week'] as Map<String, dynamic>),
+    Expr.fromJson(json['day_of_week'] as Map<String, dynamic>),
   );
 }
 
@@ -41,8 +39,7 @@ Map<String, dynamic> _$DayOfWeekToJson(DayOfWeek instance) => <String, dynamic>{
 
 DayOfYear _$DayOfYearFromJson(Map<String, dynamic> json) {
   return DayOfYear(
-    json['day_of_year'] ??
-        Expr.fromJson(json['day_of_year'] as Map<String, dynamic>),
+    Expr.fromJson(json['day_of_year'] as Map<String, dynamic>),
   );
 }
 
@@ -64,7 +61,7 @@ Map<String, dynamic> _$EpochToJson(Epoch instance) => <String, dynamic>{
 
 Hour _$HourFromJson(Map<String, dynamic> json) {
   return Hour(
-    json['hour'] ?? Expr.fromJson(json['hour'] as Map<String, dynamic>),
+    Expr.fromJson(json['hour'] as Map<String, dynamic>),
   );
 }
 
@@ -74,7 +71,7 @@ Map<String, dynamic> _$HourToJson(Hour instance) => <String, dynamic>{
 
 Minute _$MinuteFromJson(Map<String, dynamic> json) {
   return Minute(
-    json['minute'] ?? Expr.fromJson(json['minute'] as Map<String, dynamic>),
+    Expr.fromJson(json['minute'] as Map<String, dynamic>),
   );
 }
 
@@ -84,7 +81,7 @@ Map<String, dynamic> _$MinuteToJson(Minute instance) => <String, dynamic>{
 
 Month _$MonthFromJson(Map<String, dynamic> json) {
   return Month(
-    json['month'] ?? Expr.fromJson(json['month'] as Map<String, dynamic>),
+    Expr.fromJson(json['month'] as Map<String, dynamic>),
   );
 }
 
@@ -102,7 +99,7 @@ Map<String, dynamic> _$NowToJson(Now instance) => <String, dynamic>{
 
 Second _$SecondFromJson(Map<String, dynamic> json) {
   return Second(
-    json['second'] ?? Expr.fromJson(json['second'] as Map<String, dynamic>),
+    Expr.fromJson(json['second'] as Map<String, dynamic>),
   );
 }
 
@@ -122,9 +119,9 @@ Map<String, dynamic> _$TimeToJson(Time instance) => <String, dynamic>{
 
 TimeAdd _$TimeAddFromJson(Map<String, dynamic> json) {
   return TimeAdd(
-    json['time_add'],
-    json['offset'],
-    json['unit'],
+    json['time_add'] as Object,
+    json['offset'] as Object,
+    json['unit'] as Object,
   );
 }
 
@@ -136,9 +133,9 @@ Map<String, dynamic> _$TimeAddToJson(TimeAdd instance) => <String, dynamic>{
 
 TimeDiff _$TimeDiffFromJson(Map<String, dynamic> json) {
   return TimeDiff(
-    json['time_diff'],
-    json['other'],
-    json['unit'],
+    json['time_diff'] as Object,
+    json['other'] as Object,
+    json['unit'] as Object,
   );
 }
 
@@ -150,9 +147,9 @@ Map<String, dynamic> _$TimeDiffToJson(TimeDiff instance) => <String, dynamic>{
 
 TimeSubtract _$TimeSubtractFromJson(Map<String, dynamic> json) {
   return TimeSubtract(
-    json['time_subtract'],
-    json['offset'],
-    json['unit'],
+    json['time_subtract'] as Object,
+    json['offset'] as Object,
+    json['unit'] as Object,
   );
 }
 
@@ -165,7 +162,7 @@ Map<String, dynamic> _$TimeSubtractToJson(TimeSubtract instance) =>
 
 Year _$YearFromJson(Map<String, dynamic> json) {
   return Year(
-    json['year'] ?? Expr.fromJson(json['year'] as Map<String, dynamic>),
+    Expr.fromJson(json['year'] as Map<String, dynamic>),
   );
 }
 

--- a/lib/src/fql/time_and_date.g.dart
+++ b/lib/src/fql/time_and_date.g.dart
@@ -18,9 +18,8 @@ Map<String, dynamic> _$DateToJson(Date instance) => <String, dynamic>{
 
 DayOfMonth _$DayOfMonthFromJson(Map<String, dynamic> json) {
   return DayOfMonth(
-    json['day_of_month'] == null
-        ? null
-        : Expr.fromJson(json['day_of_month'] as Map<String, dynamic>),
+    json['day_of_month'] ??
+        Expr.fromJson(json['day_of_month'] as Map<String, dynamic>),
   );
 }
 
@@ -31,9 +30,8 @@ Map<String, dynamic> _$DayOfMonthToJson(DayOfMonth instance) =>
 
 DayOfWeek _$DayOfWeekFromJson(Map<String, dynamic> json) {
   return DayOfWeek(
-    json['day_of_week'] == null
-        ? null
-        : Expr.fromJson(json['day_of_week'] as Map<String, dynamic>),
+    json['day_of_week'] ??
+        Expr.fromJson(json['day_of_week'] as Map<String, dynamic>),
   );
 }
 
@@ -43,9 +41,8 @@ Map<String, dynamic> _$DayOfWeekToJson(DayOfWeek instance) => <String, dynamic>{
 
 DayOfYear _$DayOfYearFromJson(Map<String, dynamic> json) {
   return DayOfYear(
-    json['day_of_year'] == null
-        ? null
-        : Expr.fromJson(json['day_of_year'] as Map<String, dynamic>),
+    json['day_of_year'] ??
+        Expr.fromJson(json['day_of_year'] as Map<String, dynamic>),
   );
 }
 
@@ -67,9 +64,7 @@ Map<String, dynamic> _$EpochToJson(Epoch instance) => <String, dynamic>{
 
 Hour _$HourFromJson(Map<String, dynamic> json) {
   return Hour(
-    json['hour'] == null
-        ? null
-        : Expr.fromJson(json['hour'] as Map<String, dynamic>),
+    json['hour'] ?? Expr.fromJson(json['hour'] as Map<String, dynamic>),
   );
 }
 
@@ -79,9 +74,7 @@ Map<String, dynamic> _$HourToJson(Hour instance) => <String, dynamic>{
 
 Minute _$MinuteFromJson(Map<String, dynamic> json) {
   return Minute(
-    json['minute'] == null
-        ? null
-        : Expr.fromJson(json['minute'] as Map<String, dynamic>),
+    json['minute'] ?? Expr.fromJson(json['minute'] as Map<String, dynamic>),
   );
 }
 
@@ -91,9 +84,7 @@ Map<String, dynamic> _$MinuteToJson(Minute instance) => <String, dynamic>{
 
 Month _$MonthFromJson(Map<String, dynamic> json) {
   return Month(
-    json['month'] == null
-        ? null
-        : Expr.fromJson(json['month'] as Map<String, dynamic>),
+    json['month'] ?? Expr.fromJson(json['month'] as Map<String, dynamic>),
   );
 }
 
@@ -111,9 +102,7 @@ Map<String, dynamic> _$NowToJson(Now instance) => <String, dynamic>{
 
 Second _$SecondFromJson(Map<String, dynamic> json) {
   return Second(
-    json['second'] == null
-        ? null
-        : Expr.fromJson(json['second'] as Map<String, dynamic>),
+    json['second'] ?? Expr.fromJson(json['second'] as Map<String, dynamic>),
   );
 }
 
@@ -176,9 +165,7 @@ Map<String, dynamic> _$TimeSubtractToJson(TimeSubtract instance) =>
 
 Year _$YearFromJson(Map<String, dynamic> json) {
   return Year(
-    json['year'] == null
-        ? null
-        : Expr.fromJson(json['year'] as Map<String, dynamic>),
+    json['year'] ?? Expr.fromJson(json['year'] as Map<String, dynamic>),
   );
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,414 +5,386 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "17.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.39.14"
+    version: "1.1.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "2.0.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   build:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.7"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.10"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.10"
+    version: "2.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.12.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "6.1.12"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.3.2"
+    version: "5.0.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "8.0.2"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.3.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.7.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.2"
+    version: "3.0.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.6"
+    version: "1.3.14"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.11"
+    version: "1.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
+    version: "1.0.0"
   http:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.2"
+    version: "0.13.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.5"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "4.0.2"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.9"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.9.6+3"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.0"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.4"
+    version: "2.0.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4+1"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.9.6"
+    version: "0.9.10+3"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.1+2"
+    version: "0.1.1+3"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.8.1 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -30,19 +30,19 @@ packages:
     source: hosted
     version: "2.5.0"
   build:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: build
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.6.3"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.7"
+    version: "0.4.6"
   build_daemon:
     dependency: transitive
     description:
@@ -56,21 +56,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.11.5"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.12"
+    version: "6.1.10"
   built_collection:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: checked_yaml
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "1.0.4"
   cli_util:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: graphs
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.2.0"
   http:
     dependency: "direct main"
     description:
@@ -287,7 +287,7 @@ packages:
       name: pubspec_parse
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.1.8"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,19 @@
 name: faunadb_http
-version: 0.10.0
+version: 0.11.0
 description: A pure Dart implementation of a FaunaDB client and provides query classes that closely mimic FQL functions.
 homepage: https://github.com/gavanitrate/faunadb-http-dart
 
 environment:
-  sdk: '>=2.8.1 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  http: ^0.12.2
-  json_annotation: ^3.0.1
+  http: ^0.13.0
+  json_annotation: ^4.0.0
 
 dev_dependencies:
-  json_serializable: ^3.3.0
-  build_runner: ^1.10.1
-  pedantic: ^1.9.0
+  json_serializable: ^4.0.2
+  build_runner: ^1.12.1
+  pedantic: ^1.11.0
+
+dependency_overrides:
+  build: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,5 @@ dependencies:
 
 dev_dependencies:
   json_serializable: ^4.0.2
-  build_runner: ^1.12.1
+  build_runner: ^1.10.1
   pedantic: ^1.11.0
-
-dependency_overrides:
-  build: ^2.0.0


### PR DESCRIPTION
I had an issue with line 91 in the file 'result.dart': `return Result.unwrap_values(collection)`. The error was attempting to convert from 'Object?' to 'RefResult?'. Although it is a change that potentially will throw an exception, I decided to go for `return Result.unwrap_values(collection) as RefResult` in the end. I have no clue as to why Object -> RefResult worked before, and doesn't now.